### PR TITLE
Date ranges

### DIFF
--- a/TAT_audit/templates/audit_template.html
+++ b/TAT_audit/templates/audit_template.html
@@ -33,7 +33,7 @@
 
 </head>
 <body>
-    <div class="all_content" style="width: 800px; margin-left: 350px; padding-top: 20px; padding-bottom: 20px;">
+    <div class="all_content" style="width:800px; margin:0 auto;">
         <h2>Audit Results</h2>
         <p>Audit standards:</p>
         <ul>

--- a/TAT_audit/templates/audit_template.html
+++ b/TAT_audit/templates/audit_template.html
@@ -53,8 +53,21 @@
                 100% processing and releasing of SNP data in 3 calendar days
             </li>
         </ul>
-        <p>NB: In cases where a Jira ticket is found for a run but this does not match a 002 project this could be for a number or reasons. For example, the 002 project was not created within the audit period, the date of the run itself is not between the audit dates, the DNAnexus authorisation token does not have correct permissions to view the 002 project or the ticket name has more than 2 differences compared to the run name and so they are not considered a match.</p>
-
+        <p>NB: In cases where a Jira ticket is found for a run but this does not match a 002 project this could be for a number or reasons. For example:</p>
+        <ul>
+            <li>
+                The 002 project was not created within the audit period
+            </li>
+            <li>
+                The date of the run itself is not between the audit dates
+            </li>
+            <li>
+                The DNAnexus authorisation token does not have correct permissions to view the 002 project
+            </li>
+            <li>
+                The ticket name has more than 2 differences compared to the run name and so they are not considered a match
+            </li>
+        </ul>
         <div style="padding-top: 30px; padding-bottom: 20px;">
             <h4>CEN Runs</h4>
             {{ chart_1 }}

--- a/TAT_audit/templates/audit_template.html
+++ b/TAT_audit/templates/audit_template.html
@@ -53,6 +53,7 @@
                 100% processing and releasing of SNP data in 3 calendar days
             </li>
         </ul>
+        <p>NB: In cases where a Jira ticket is found for a run but this does not match a 002 project this could be for a number or reasons. For example, the 002 project was not created within the audit period, the date of the run itself is not between the audit dates, the DNAnexus authorisation token does not have correct permissions to view the 002 project or the ticket name has more than 2 differences compared to the run name and so they are not considered a match.</p>
 
         <div style="padding-top: 30px; padding-bottom: 20px;">
             <h4>CEN Runs</h4>
@@ -146,7 +147,7 @@
         {% if runs_no_002 %}
         {% if "CEN" in runs_no_002|map(attribute="assay_type") %}
         <div style="padding-top: 20px;">
-            <h5>Jira tickets found for released runs but no 002 project found (that was created within the audit period for a run between the audit dates):</h5>
+            <h5>Jira tickets found for released runs but no 002 project found:</h5>
         {% for item in runs_no_002 %}
             {% if item.assay_type == "CEN" %}
                     <p><b>{{ item.run_name }}</b></p>
@@ -166,59 +167,6 @@
         {% endfor %}
         </div>
         {% endif %}
-        {% endif %}
-
-        {% if closed_ticket_typos %}
-        {% if "CEN" in closed_ticket_typos|map(attribute="assay_type") %}
-        <div style="padding-top: 20px; padding-bottom: 20px;">
-        <h5>Mismatches between StagingArea run folder name and Jira ticket (closed tickets)</h5>
-        {% for item in closed_ticket_typos %}
-            {% if item.assay_type == "CEN" %}
-                <b>Run folder name:</b> {{ item.run_name }}
-                <br>
-                <b>Jira ticket name:</b> {{ item.jira_ticket_name }}
-                <br>
-                <br>
-            {% endif %}
-        {% endfor %}
-        </div>
-        {% endif %}
-        {% endif %}
-
-        {% if open_ticket_typos %}
-        {% if "CEN" in open_ticket_typos|map(attribute="assay_type") %}
-        <div style="padding-top: 20px; padding-bottom: 20px;">
-            <h5>Mismatches between StagingArea run folder name and Jira ticket (open tickets)</h5>
-            {% for item in open_ticket_typos %}
-            {% if item.assay_type == "CEN" %}
-                <b>Run folder name:</b> {{ item.run_name }}
-                <br>
-                <b>Jira ticket name:</b> {{ item.jira_ticket_name }}
-                <br>
-                <br>
-            {% endif %}
-            {% endfor %}
-        </div>
-        {% endif %}
-        {% endif %}
-
-        {% if typo_folders %}
-        {% for assay_dict in typo_folders %}
-        {% for assay_name, values in assay_dict.items() %}
-        {% if assay_name == "CEN" %}
-            <div style="padding-top: 20px; padding-bottom: 20px;">
-            <h5>Mismatches between StagingArea run folder name and 002 project name</h5>
-            {% for value in values %}
-                <b>Run folder name:</b> {{ value.folder_name }}
-                <br>
-                <b>002 project name:</b> {{ value.project_name_002 }}
-                <br>
-                <br>
-            {% endfor %}
-        </div>
-        {% endif %}
-        {% endfor %}
-        {% endfor %}
         {% endif %}
 
         {% if cancelled_runs %}
@@ -336,7 +284,7 @@
         {% if runs_no_002 %}
         {% if "MYE" in runs_no_002|map(attribute="assay_type") %}
         <div style="padding-top: 20px;">
-            <h5>Jira tickets found for released runs but no 002 project found (that was created within the audit period for a run between the audit dates):</h5>
+            <h5>Jira tickets found for released runs but no 002 project found:</h5>
         {% for item in runs_no_002 %}
             {% if item.assay_type == "MYE" %}
                     <p><b>{{ item.run_name }}</b></p>
@@ -356,59 +304,6 @@
         {% endfor %}
         </div>
         {% endif %}
-        {% endif %}
-
-        {% if closed_ticket_typos %}
-        {% if "MYE" in closed_ticket_typos|map(attribute="assay_type") %}
-        <div style="padding-top: 20px; padding-bottom: 20px;">
-        <h5>Mismatches between StagingArea run folder name and Jira ticket (closed tickets)</h5>
-        {% for item in closed_ticket_typos %}
-            {% if item.assay_type == "MYE" %}
-                <b>Run folder name:</b> {{ item.run_name }}
-                <br>
-                <b>Jira ticket name:</b> {{ item.jira_ticket_name }}
-                <br>
-                <br>
-            {% endif %}
-        {% endfor %}
-        </div>
-        {% endif %}
-        {% endif %}
-
-        {% if open_ticket_typos %}
-        {% if "MYE" in open_ticket_typos|map(attribute="assay_type") %}
-        <div style="padding-top: 20px; padding-bottom: 20px;">
-            <h5>Mismatches between StagingArea run folder name and Jira ticket (open tickets)</h5>
-            {% for item in open_ticket_typos %}
-            {% if item.assay_type == "MYE" %}
-                <b>Run folder name:</b> {{ item.run_name }}
-                <br>
-                <b>Jira ticket name:</b> {{ item.jira_ticket_name }}
-                <br>
-                <br>
-            {% endif %}
-            {% endfor %}
-        </div>
-        {% endif %}
-        {% endif %}
-
-        {% if typo_folders %}
-        {% for assay_dict in typo_folders %}
-        {% for assay_name, values in assay_dict.items() %}
-        {% if assay_name == "MYE" %}
-        <div style="padding-top: 20px; padding-bottom: 20px;">
-            <h5>Mismatches between StagingArea run folder name and 002 project name</h5>
-            {% for value in values %}
-                <b>Run folder name:</b> {{ value.folder_name }}
-                <br>
-                <b>002 project name:</b> {{ value.project_name_002 }}
-                <br>
-                <br>
-            {% endfor %}
-        </div>
-        {% endif %}
-        {% endfor %}
-        {% endfor %}
         {% endif %}
 
         {% if cancelled_runs %}
@@ -526,7 +421,7 @@
         {% if runs_no_002 %}
         {% if "TSO500" in runs_no_002|map(attribute="assay_type") %}
         <div style="padding-top: 20px;">
-            <h5>Jira tickets found for released runs but no 002 project found (that was created within the audit period for a run between the audit dates):</h5>
+            <h5>Jira tickets found for released runs but no 002 project found:</h5>
         {% for item in runs_no_002 %}
             {% if item.assay_type == "TSO500" %}
                     <p><b>{{ item.run_name }}</b></p>
@@ -546,59 +441,6 @@
         {% endfor %}
         </div>
         {% endif %}
-        {% endif %}
-
-        {% if closed_ticket_typos %}
-        {% if "TSO500" in closed_ticket_typos|map(attribute="assay_type") %}
-        <div style="padding-top: 20px; padding-bottom: 20px;">
-        <h5>Mismatches between StagingArea run folder name and Jira ticket (closed tickets)</h5>
-        {% for item in closed_ticket_typos %}
-            {% if item.assay_type == "TSO500" %}
-                <b>Run folder name:</b> {{ item.run_name }}
-                <br>
-                <b>Jira ticket name:</b> {{ item.jira_ticket_name }}
-                <br>
-                <br>
-            {% endif %}
-        {% endfor %}
-        </div>
-        {% endif %}
-        {% endif %}
-
-        {% if open_ticket_typos %}
-        {% if "TSO500" in open_ticket_typos|map(attribute="assay_type") %}
-        <div style="padding-top: 20px; padding-bottom: 20px;">
-            <h5>Mismatches between StagingArea run folder name and Jira ticket (open tickets)</h5>
-            {% for item in open_ticket_typos %}
-            {% if item.assay_type == "TSO500" %}
-                <b>Run folder name:</b> {{ item.run_name }}
-                <br>
-                <b>Jira ticket name:</b> {{ item.jira_ticket_name }}
-                <br>
-                <br>
-            {% endif %}
-            {% endfor %}
-        </div>
-        {% endif %}
-        {% endif %}
-
-        {% if typo_folders %}
-        {% for assay_dict in typo_folders %}
-        {% for assay_name, values in assay_dict.items() %}
-        {% if assay_name == "TSO500" %}
-        <div style="padding-top: 20px; padding-bottom: 20px;">
-            <h5>Mismatches between StagingArea run folder name 002 project name</h5>
-            {% for value in values %}
-                <b>Run folder name:</b> {{ value.folder_name }}
-                <br>
-                <b>002 project name:</b> {{ value.project_name_002 }}
-                <br>
-                <br>
-            {% endfor %}
-        </div>
-        {% endif %}
-        {% endfor %}
-        {% endfor %}
         {% endif %}
 
         {% if cancelled_runs %}
@@ -716,7 +558,7 @@
         {% if runs_no_002 %}
         {% if "TWE" in runs_no_002|map(attribute="assay_type") %}
         <div style="padding-top: 20px;">
-            <h5>Jira tickets found for released runs but no 002 project found (that was created within the audit period for a run between the audit dates):</h5>
+            <h5>Jira tickets found for released runs but no 002 project found:</h5>
         {% for item in runs_no_002 %}
             {% if item.assay_type == "TWE" %}
                     <p><b>{{ item.run_name }}</b></p>
@@ -736,59 +578,6 @@
         {% endfor %}
         </div>
         {% endif %}
-        {% endif %}
-
-        {% if closed_ticket_typos %}
-        {% if "TWE" in closed_ticket_typos|map(attribute="assay_type") %}
-        <div style="padding-top: 20px; padding-bottom: 20px;">
-        <h5>Mismatches between StagingArea run folder name and Jira ticket (closed tickets)</h5>
-        {% for item in closed_ticket_typos %}
-            {% if item.assay_type == "TWE" %}
-                <b>Run folder name:</b> {{ item.run_name }}
-                <br>
-                <b>Jira ticket name:</b> {{ item.jira_ticket_name }}
-                <br>
-                <br>
-            {% endif %}
-        {% endfor %}
-        </div>
-        {% endif %}
-        {% endif %}
-
-        {% if open_ticket_typos %}
-        {% if "TWE" in open_ticket_typos|map(attribute="assay_type") %}
-        <div style="padding-top: 20px; padding-bottom: 20px;">
-            <h5>Mismatches between StagingArea run folder name and Jira ticket (open tickets)</h5>
-            {% for item in open_ticket_typos %}
-            {% if item.assay_type == "TWE" %}
-                <b>Run folder name:</b> {{ item.run_name }}
-                <br>
-                <b>Jira ticket name:</b> {{ item.jira_ticket_name }}
-                <br>
-                <br>
-            {% endif %}
-            {% endfor %}
-        </div>
-        {% endif %}
-        {% endif %}
-
-        {% if typo_folders %}
-        {% for assay_dict in typo_folders %}
-        {% for assay_name, values in assay_dict.items() %}
-        {% if assay_name == "TWE" %}
-        <div style="padding-top: 20px; padding-bottom: 20px;">
-            <h5>Mismatches between StagingArea run folder name and 002 project name</h5>
-            {% for value in values %}
-                <b>Run folder name:</b> {{ value.folder_name }}
-                <br>
-                <b>002 project name:</b> {{ value.project_name_002 }}
-                <br>
-                <br>
-            {% endfor %}
-        </div>
-        {% endif %}
-        {% endfor %}
-        {% endfor %}
         {% endif %}
 
         {% if cancelled_runs %}
@@ -906,7 +695,7 @@
         {% if runs_no_002 %}
         {% if "SNP" in runs_no_002|map(attribute="assay_type") %}
         <div style="padding-top: 20px;">
-            <h5>Jira tickets found for released runs but no 002 project found (that was created within the audit period for a run between the audit dates):</h5>
+            <h5>Jira tickets found for released runs but no 002 project found:</h5>
         {% for item in runs_no_002 %}
             {% if item.assay_type == "SNP" %}
                     <p><b>{{ item.run_name }}</b></p>
@@ -926,59 +715,6 @@
         {% endfor %}
         </div>
         {% endif %}
-        {% endif %}
-
-        {% if closed_ticket_typos %}
-        {% if "SNP" in closed_ticket_typos|map(attribute="assay_type") %}
-        <div style="padding-top: 20px; padding-bottom: 20px;">
-        <h5>Mismatches between StagingArea run folder name and Jira ticket (closed tickets)</h5>
-        {% for item in closed_ticket_typos %}
-            {% if item.assay_type == "SNP" %}
-                <b>Run folder name:</b> {{ item.run_name }}
-                <br>
-                <b>Jira ticket name:</b> {{ item.jira_ticket_name }}
-                <br>
-                <br>
-            {% endif %}
-        {% endfor %}
-        </div>
-        {% endif %}
-        {% endif %}
-
-        {% if open_ticket_typos %}
-        {% if "SNP" in open_ticket_typos|map(attribute="assay_type") %}
-        <div style="padding-top: 20px; padding-bottom: 20px;">
-            <h5>Mismatches between StagingArea run folder name and Jira ticket (open tickets)</h5>
-            {% for item in open_ticket_typos %}
-            {% if item.assay_type == "SNP" %}
-                <b>Run folder name:</b> {{ item.run_name }}
-                <br>
-                <b>Jira ticket name:</b> {{ item.jira_ticket_name }}
-                <br>
-                <br>
-            {% endif %}
-            {% endfor %}
-        </div>
-        {% endif %}
-        {% endif %}
-
-        {% if typo_folders %}
-        {% for assay_dict in typo_folders %}
-        {% for assay_name, values in assay_dict.items() %}
-        {% if assay_name == "SNP" %}
-        <div style="padding-top: 20px; padding-bottom: 20px;">
-            <h5>Mismatches between StagingArea run folder name and 002 project name</h5>
-            {% for value in values %}
-                <b>Run folder name:</b> {{ value.folder_name }}
-                <br>
-                <b>002 project name:</b> {{ value.project_name_002 }}
-                <br>
-                <br>
-            {% endfor %}
-        </div>
-        {% endif %}
-        {% endfor %}
-        {% endfor %}
         {% endif %}
 
         {% if cancelled_runs %}
@@ -1003,7 +739,19 @@
         {% endif %}
         {% endif %}
 
+    {% if ticket_typos %}
+    <div style="padding-top: 20px; padding-bottom: 20px;">
+        <h5>All mismatches between Staging_Area52 run folder name and Jira ticket name</h5>
+        {{ ticket_typos }}
     </div>
+    {% endif %}
+
+    {% if typo_folders %}
+    <div style="padding-top: 20px; padding-bottom: 20px;">
+        <h5>All mismatches between Staging_Area52 run folder name and 002 project name</h5>
+        {{ typo_folders }}
+    </div>
+    {% endif %}
 
     <script>
         // Sets up DataTables

--- a/TAT_audit/templates/audit_template.html
+++ b/TAT_audit/templates/audit_template.html
@@ -56,7 +56,7 @@
 
         <div style="padding-top: 30px; padding-bottom: 20px;">
             <h4>CEN Runs</h4>
-            {{ chart_1 }} 
+            {{ chart_1 }}
         </div>
         <div style="width: 600px; margin-left: 150px; padding-bottom: 20px;">
             {{ averages_1 }}
@@ -102,7 +102,7 @@
                 {% endif %}
 
                 {% if runs_to_review_1.no_002_found %}
-                    <p><b>No 002 job was found:</b></p> 
+                    <p><b>No 002 job was found:</b></p>
                     <ul>
                         {% for entry in runs_to_review_1.no_002_found  %}
                             <li>{{ entry }}</li>
@@ -146,7 +146,7 @@
         {% if runs_no_002 %}
         {% if "CEN" in runs_no_002|map(attribute="assay_type") %}
         <div style="padding-top: 20px;">
-            <h5>Released runs with no 002 project found:</h5>
+            <h5>Jira tickets found for released runs but no 002 project found (that was created within the audit period for a run between the audit dates):</h5>
         {% for item in runs_no_002 %}
             {% if item.assay_type == "CEN" %}
                     <p><b>{{ item.run_name }}</b></p>
@@ -171,12 +171,12 @@
         {% if closed_ticket_typos %}
         {% if "CEN" in closed_ticket_typos|map(attribute="assay_type") %}
         <div style="padding-top: 20px; padding-bottom: 20px;">
-        <h5>Mismatches between run folder name and Jira ticket (closed tickets)</h5>
+        <h5>Mismatches between StagingArea run folder name and Jira ticket (closed tickets)</h5>
         {% for item in closed_ticket_typos %}
             {% if item.assay_type == "CEN" %}
-                <b>Jira ticket name:</b> {{ item.jira_ticket_name }}
-                <br>
                 <b>Run folder name:</b> {{ item.run_name }}
+                <br>
+                <b>Jira ticket name:</b> {{ item.jira_ticket_name }}
                 <br>
                 <br>
             {% endif %}
@@ -188,12 +188,12 @@
         {% if open_ticket_typos %}
         {% if "CEN" in open_ticket_typos|map(attribute="assay_type") %}
         <div style="padding-top: 20px; padding-bottom: 20px;">
-            <h5>Mismatches between run folder name and Jira ticket (open tickets)</h5>
+            <h5>Mismatches between StagingArea run folder name and Jira ticket (open tickets)</h5>
             {% for item in open_ticket_typos %}
             {% if item.assay_type == "CEN" %}
-                <b>Jira ticket name:</b> {{ item.jira_ticket_name }}
-                <br>
                 <b>Run folder name:</b> {{ item.run_name }}
+                <br>
+                <b>Jira ticket name:</b> {{ item.jira_ticket_name }}
                 <br>
                 <br>
             {% endif %}
@@ -207,7 +207,7 @@
         {% for assay_name, values in assay_dict.items() %}
         {% if assay_name == "CEN" %}
             <div style="padding-top: 20px; padding-bottom: 20px;">
-            <h5>Mismatches between 002 project name and StagingArea run folder</h5>
+            <h5>Mismatches between StagingArea run folder name and 002 project name</h5>
             {% for value in values %}
                 <b>Run folder name:</b> {{ value.folder_name }}
                 <br>
@@ -336,7 +336,7 @@
         {% if runs_no_002 %}
         {% if "MYE" in runs_no_002|map(attribute="assay_type") %}
         <div style="padding-top: 20px;">
-            <h5>Released runs with no 002 project found:</h5>
+            <h5>Jira tickets found for released runs but no 002 project found (that was created within the audit period for a run between the audit dates):</h5>
         {% for item in runs_no_002 %}
             {% if item.assay_type == "MYE" %}
                     <p><b>{{ item.run_name }}</b></p>
@@ -361,12 +361,12 @@
         {% if closed_ticket_typos %}
         {% if "MYE" in closed_ticket_typos|map(attribute="assay_type") %}
         <div style="padding-top: 20px; padding-bottom: 20px;">
-        <h5>Mismatches between run folder name and Jira ticket (closed tickets)</h5>
+        <h5>Mismatches between StagingArea run folder name and Jira ticket (closed tickets)</h5>
         {% for item in closed_ticket_typos %}
             {% if item.assay_type == "MYE" %}
-                <b>Jira ticket name:</b> {{ item.jira_ticket_name }}
-                <br>
                 <b>Run folder name:</b> {{ item.run_name }}
+                <br>
+                <b>Jira ticket name:</b> {{ item.jira_ticket_name }}
                 <br>
                 <br>
             {% endif %}
@@ -378,12 +378,12 @@
         {% if open_ticket_typos %}
         {% if "MYE" in open_ticket_typos|map(attribute="assay_type") %}
         <div style="padding-top: 20px; padding-bottom: 20px;">
-            <h5>Mismatches between run folder name and Jira ticket (open tickets)</h5>
+            <h5>Mismatches between StagingArea run folder name and Jira ticket (open tickets)</h5>
             {% for item in open_ticket_typos %}
             {% if item.assay_type == "MYE" %}
-                <b>Jira ticket name:</b> {{ item.jira_ticket_name }}
-                <br>
                 <b>Run folder name:</b> {{ item.run_name }}
+                <br>
+                <b>Jira ticket name:</b> {{ item.jira_ticket_name }}
                 <br>
                 <br>
             {% endif %}
@@ -397,7 +397,7 @@
         {% for assay_name, values in assay_dict.items() %}
         {% if assay_name == "MYE" %}
         <div style="padding-top: 20px; padding-bottom: 20px;">
-            <h5>Mismatches between 002 project name and StagingArea run folder</h5>
+            <h5>Mismatches between StagingArea run folder name and 002 project name</h5>
             {% for value in values %}
                 <b>Run folder name:</b> {{ value.folder_name }}
                 <br>
@@ -526,7 +526,7 @@
         {% if runs_no_002 %}
         {% if "TSO500" in runs_no_002|map(attribute="assay_type") %}
         <div style="padding-top: 20px;">
-            <h5>Released runs with no 002 project found:</h5>
+            <h5>Jira tickets found for released runs but no 002 project found (that was created within the audit period for a run between the audit dates):</h5>
         {% for item in runs_no_002 %}
             {% if item.assay_type == "TSO500" %}
                     <p><b>{{ item.run_name }}</b></p>
@@ -551,12 +551,12 @@
         {% if closed_ticket_typos %}
         {% if "TSO500" in closed_ticket_typos|map(attribute="assay_type") %}
         <div style="padding-top: 20px; padding-bottom: 20px;">
-        <h5>Mismatches between run folder name and Jira ticket (closed tickets)</h5>
+        <h5>Mismatches between StagingArea run folder name and Jira ticket (closed tickets)</h5>
         {% for item in closed_ticket_typos %}
             {% if item.assay_type == "TSO500" %}
-                <b>Jira ticket name:</b> {{ item.jira_ticket_name }}
-                <br>
                 <b>Run folder name:</b> {{ item.run_name }}
+                <br>
+                <b>Jira ticket name:</b> {{ item.jira_ticket_name }}
                 <br>
                 <br>
             {% endif %}
@@ -568,12 +568,12 @@
         {% if open_ticket_typos %}
         {% if "TSO500" in open_ticket_typos|map(attribute="assay_type") %}
         <div style="padding-top: 20px; padding-bottom: 20px;">
-            <h5>Mismatches between run folder name and Jira ticket (open tickets)</h5>
+            <h5>Mismatches between StagingArea run folder name and Jira ticket (open tickets)</h5>
             {% for item in open_ticket_typos %}
             {% if item.assay_type == "TSO500" %}
-                <b>Jira ticket name:</b> {{ item.jira_ticket_name }}
-                <br>
                 <b>Run folder name:</b> {{ item.run_name }}
+                <br>
+                <b>Jira ticket name:</b> {{ item.jira_ticket_name }}
                 <br>
                 <br>
             {% endif %}
@@ -587,7 +587,7 @@
         {% for assay_name, values in assay_dict.items() %}
         {% if assay_name == "TSO500" %}
         <div style="padding-top: 20px; padding-bottom: 20px;">
-            <h5>Mismatches between 002 project name and StagingArea run folder</h5>
+            <h5>Mismatches between StagingArea run folder name 002 project name</h5>
             {% for value in values %}
                 <b>Run folder name:</b> {{ value.folder_name }}
                 <br>
@@ -672,7 +672,7 @@
                 {% endif %}
 
                 {% if runs_to_review_4.no_002_found %}
-                    <p><b>No 002 job was found:</b></p> 
+                    <p><b>No 002 job was found:</b></p>
                     <ul>
                         {% for entry in runs_to_review_4.no_002_found  %}
                             <li>{{ entry }}</li>
@@ -716,7 +716,7 @@
         {% if runs_no_002 %}
         {% if "TWE" in runs_no_002|map(attribute="assay_type") %}
         <div style="padding-top: 20px;">
-            <h5>Released runs with no 002 project found:</h5>
+            <h5>Jira tickets found for released runs but no 002 project found (that was created within the audit period for a run between the audit dates):</h5>
         {% for item in runs_no_002 %}
             {% if item.assay_type == "TWE" %}
                     <p><b>{{ item.run_name }}</b></p>
@@ -741,12 +741,12 @@
         {% if closed_ticket_typos %}
         {% if "TWE" in closed_ticket_typos|map(attribute="assay_type") %}
         <div style="padding-top: 20px; padding-bottom: 20px;">
-        <h5>Mismatches between run folder name and Jira ticket (closed tickets)</h5>
+        <h5>Mismatches between StagingArea run folder name and Jira ticket (closed tickets)</h5>
         {% for item in closed_ticket_typos %}
             {% if item.assay_type == "TWE" %}
-                <b>Jira ticket name:</b> {{ item.jira_ticket_name }}
-                <br>
                 <b>Run folder name:</b> {{ item.run_name }}
+                <br>
+                <b>Jira ticket name:</b> {{ item.jira_ticket_name }}
                 <br>
                 <br>
             {% endif %}
@@ -758,12 +758,12 @@
         {% if open_ticket_typos %}
         {% if "TWE" in open_ticket_typos|map(attribute="assay_type") %}
         <div style="padding-top: 20px; padding-bottom: 20px;">
-            <h5>Mismatches between run folder name and Jira ticket (open tickets)</h5>
+            <h5>Mismatches between StagingArea run folder name and Jira ticket (open tickets)</h5>
             {% for item in open_ticket_typos %}
             {% if item.assay_type == "TWE" %}
-                <b>Jira ticket name:</b> {{ item.jira_ticket_name }}
-                <br>
                 <b>Run folder name:</b> {{ item.run_name }}
+                <br>
+                <b>Jira ticket name:</b> {{ item.jira_ticket_name }}
                 <br>
                 <br>
             {% endif %}
@@ -777,7 +777,7 @@
         {% for assay_name, values in assay_dict.items() %}
         {% if assay_name == "TWE" %}
         <div style="padding-top: 20px; padding-bottom: 20px;">
-            <h5>Mismatches between 002 project name and StagingArea run folder</h5>
+            <h5>Mismatches between StagingArea run folder name and 002 project name</h5>
             {% for value in values %}
                 <b>Run folder name:</b> {{ value.folder_name }}
                 <br>
@@ -906,7 +906,7 @@
         {% if runs_no_002 %}
         {% if "SNP" in runs_no_002|map(attribute="assay_type") %}
         <div style="padding-top: 20px;">
-            <h5>Released runs with no 002 project found:</h5>
+            <h5>Jira tickets found for released runs but no 002 project found (that was created within the audit period for a run between the audit dates):</h5>
         {% for item in runs_no_002 %}
             {% if item.assay_type == "SNP" %}
                     <p><b>{{ item.run_name }}</b></p>
@@ -931,12 +931,12 @@
         {% if closed_ticket_typos %}
         {% if "SNP" in closed_ticket_typos|map(attribute="assay_type") %}
         <div style="padding-top: 20px; padding-bottom: 20px;">
-        <h5>Mismatches between run folder name and Jira ticket (closed tickets)</h5>
+        <h5>Mismatches between StagingArea run folder name and Jira ticket (closed tickets)</h5>
         {% for item in closed_ticket_typos %}
             {% if item.assay_type == "SNP" %}
-                <b>Jira ticket name:</b> {{ item.jira_ticket_name }}
-                <br>
                 <b>Run folder name:</b> {{ item.run_name }}
+                <br>
+                <b>Jira ticket name:</b> {{ item.jira_ticket_name }}
                 <br>
                 <br>
             {% endif %}
@@ -948,12 +948,12 @@
         {% if open_ticket_typos %}
         {% if "SNP" in open_ticket_typos|map(attribute="assay_type") %}
         <div style="padding-top: 20px; padding-bottom: 20px;">
-            <h5>Mismatches between run folder name and Jira ticket (open tickets)</h5>
+            <h5>Mismatches between StagingArea run folder name and Jira ticket (open tickets)</h5>
             {% for item in open_ticket_typos %}
             {% if item.assay_type == "SNP" %}
-                <b>Jira ticket name:</b> {{ item.jira_ticket_name }}
-                <br>
                 <b>Run folder name:</b> {{ item.run_name }}
+                <br>
+                <b>Jira ticket name:</b> {{ item.jira_ticket_name }}
                 <br>
                 <br>
             {% endif %}
@@ -967,7 +967,7 @@
         {% for assay_name, values in assay_dict.items() %}
         {% if assay_name == "SNP" %}
         <div style="padding-top: 20px; padding-bottom: 20px;">
-            <h5>Mismatches between 002 project name and StagingArea run folder</h5>
+            <h5>Mismatches between StagingArea run folder name and 002 project name</h5>
             {% for value in values %}
                 <b>Run folder name:</b> {{ value.folder_name }}
                 <br>

--- a/TAT_audit/templates/audit_template.html
+++ b/TAT_audit/templates/audit_template.html
@@ -143,28 +143,6 @@
         {% endif %}
         {% endif %}
 
-        {% if cancelled_runs %}
-        {% if "CEN" in cancelled_runs|map(attribute="assay_type") %}
-        <div style="padding-top: 30px; padding-bottom: 30px;">
-            <h5>Runs that were not completed:</h5>
-        {% for run in cancelled_runs %}
-            {% if run.assay_type == 'CEN' %}
-                <p><b>{{ run.run_name }}</b></p>
-                <ul>
-                    <li>
-                        Date Jira ticket created: {{ run.date_jira_ticket_created }}
-                    </li>
-                    <li>
-                        Reason run not released: {{ run.reason_not_released }}
-                    </li>
-                </ul>
-                <br>
-            {% endif %}
-        {% endfor %}
-        </div>
-        {% endif %}
-        {% endif %}
-
         {% if runs_no_002 %}
         {% if "CEN" in runs_no_002|map(attribute="assay_type") %}
         <div style="padding-top: 20px;">
@@ -193,12 +171,13 @@
         {% if closed_ticket_typos %}
         {% if "CEN" in closed_ticket_typos|map(attribute="assay_type") %}
         <div style="padding-top: 20px; padding-bottom: 20px;">
-        <h5>Mismatches between 002 project name and Jira ticket (closed tickets)</h5>
+        <h5>Mismatches between run folder name and Jira ticket (closed tickets)</h5>
         {% for item in closed_ticket_typos %}
             {% if item.assay_type == "CEN" %}
                 <b>Jira ticket name:</b> {{ item.jira_ticket_name }}
                 <br>
-                <b>002 project name:</b> {{ item.project_name_002 }}
+                <b>Run folder name:</b> {{ item.run_name }}
+                <br>
                 <br>
             {% endif %}
         {% endfor %}
@@ -209,12 +188,13 @@
         {% if open_ticket_typos %}
         {% if "CEN" in open_ticket_typos|map(attribute="assay_type") %}
         <div style="padding-top: 20px; padding-bottom: 20px;">
-            <h5>Mismatches between 002 project name and Jira ticket (open tickets)</h5>
+            <h5>Mismatches between run folder name and Jira ticket (open tickets)</h5>
             {% for item in open_ticket_typos %}
             {% if item.assay_type == "CEN" %}
                 <b>Jira ticket name:</b> {{ item.jira_ticket_name }}
                 <br>
-                <b>002 project name:</b> {{ item.project_name_002 }}
+                <b>Run folder name:</b> {{ item.run_name }}
+                <br>
                 <br>
             {% endif %}
             {% endfor %}
@@ -239,6 +219,28 @@
         {% endif %}
         {% endfor %}
         {% endfor %}
+        {% endif %}
+
+        {% if cancelled_runs %}
+        {% if "CEN" in cancelled_runs|map(attribute="assay_type") %}
+        <div style="padding-top: 30px; padding-bottom: 30px;">
+            <h5>Runs that were not completed:</h5>
+        {% for run in cancelled_runs %}
+            {% if run.assay_type == 'CEN' %}
+                <p><b>{{ run.run_name }}</b></p>
+                <ul>
+                    <li>
+                        Date Jira ticket created: {{ run.date_jira_ticket_created }}
+                    </li>
+                    <li>
+                        Reason run not released: {{ run.reason_not_released }}
+                    </li>
+                </ul>
+                <br>
+            {% endif %}
+        {% endfor %}
+        </div>
+        {% endif %}
         {% endif %}
 
 
@@ -290,7 +292,7 @@
                 {% endif %}
 
                 {% if runs_to_review_2.no_002_found %}
-                    <p><b>No 002 job was found:</b></p> 
+                    <p><b>No 002 job was found:</b></p>
                     <ul>
                         {% for entry in runs_to_review_2.no_002_found  %}
                             <li>{{ entry }}</li>
@@ -331,28 +333,6 @@
         {% endif %}
         {% endif %}
 
-        {% if cancelled_runs %}
-        {% if "MYE" in cancelled_runs|map(attribute="assay_type") %}
-        <div style="padding-top: 30px; padding-bottom: 30px;">
-            <h5>Runs that were not completed:</h5>
-        {% for run in cancelled_runs %}
-            {% if run.assay_type == 'MYE' %}
-                <p><b>{{ run.run_name }}</b></p>
-                <ul>
-                    <li>
-                        Date Jira ticket created: {{ run.date_jira_ticket_created }}
-                    </li>
-                    <li>
-                        Reason run not released: {{ run.reason_not_released }}
-                    </li>
-                </ul>
-                <br>
-            {% endif %}
-        {% endfor %}
-        </div>
-        {% endif %}
-        {% endif %}
-
         {% if runs_no_002 %}
         {% if "MYE" in runs_no_002|map(attribute="assay_type") %}
         <div style="padding-top: 20px;">
@@ -381,12 +361,13 @@
         {% if closed_ticket_typos %}
         {% if "MYE" in closed_ticket_typos|map(attribute="assay_type") %}
         <div style="padding-top: 20px; padding-bottom: 20px;">
-        <h5>Mismatches between 002 project name and Jira ticket (closed tickets)</h5>
+        <h5>Mismatches between run folder name and Jira ticket (closed tickets)</h5>
         {% for item in closed_ticket_typos %}
             {% if item.assay_type == "MYE" %}
                 <b>Jira ticket name:</b> {{ item.jira_ticket_name }}
                 <br>
-                <b>002 project name:</b> {{ item.project_name_002 }}
+                <b>Run folder name:</b> {{ item.run_name }}
+                <br>
                 <br>
             {% endif %}
         {% endfor %}
@@ -397,12 +378,13 @@
         {% if open_ticket_typos %}
         {% if "MYE" in open_ticket_typos|map(attribute="assay_type") %}
         <div style="padding-top: 20px; padding-bottom: 20px;">
-            <h5>Mismatches between 002 project name and Jira ticket (open tickets)</h5>
+            <h5>Mismatches between run folder name and Jira ticket (open tickets)</h5>
             {% for item in open_ticket_typos %}
             {% if item.assay_type == "MYE" %}
                 <b>Jira ticket name:</b> {{ item.jira_ticket_name }}
                 <br>
-                <b>002 project name:</b> {{ item.project_name_002 }}
+                <b>Run folder name:</b> {{ item.run_name }}
+                <br>
                 <br>
             {% endif %}
             {% endfor %}
@@ -427,6 +409,28 @@
         {% endif %}
         {% endfor %}
         {% endfor %}
+        {% endif %}
+
+        {% if cancelled_runs %}
+        {% if "MYE" in cancelled_runs|map(attribute="assay_type") %}
+        <div style="padding-top: 30px; padding-bottom: 30px;">
+            <h5>Runs that were not completed:</h5>
+        {% for run in cancelled_runs %}
+            {% if run.assay_type == 'MYE' %}
+                <p><b>{{ run.run_name }}</b></p>
+                <ul>
+                    <li>
+                        Date Jira ticket created: {{ run.date_jira_ticket_created }}
+                    </li>
+                    <li>
+                        Reason run not released: {{ run.reason_not_released }}
+                    </li>
+                </ul>
+                <br>
+            {% endif %}
+        {% endfor %}
+        </div>
+        {% endif %}
         {% endif %}
 
         <div style="padding-top: 30px; padding-bottom: 20px;">
@@ -478,7 +482,7 @@
                 {% endif %}
 
                 {% if runs_to_review_3.no_002_found %}
-                    <p><b>No 002 job was found:</b></p> 
+                    <p><b>No 002 job was found:</b></p>
                     <ul>
                         {% for entry in runs_to_review_3.no_002_found  %}
                             <li>{{ entry }}</li>
@@ -519,28 +523,6 @@
         {% endif %}
         {% endif %}
 
-        {% if cancelled_runs %}
-        {% if "TSO500" in cancelled_runs|map(attribute="assay_type") %}
-        <div style="padding-top: 30px; padding-bottom: 30px;">
-            <h5>Runs that were not completed:</h5>
-        {% for run in cancelled_runs %}
-            {% if run.assay_type == 'TSO500' %}
-                <p><b>{{ run.run_name }}</b></p>
-                <ul>
-                    <li>
-                        Date Jira ticket created: {{ run.date_jira_ticket_created }}
-                    </li>
-                    <li>
-                        Reason run not released: {{ run.reason_not_released }}
-                    </li>
-                </ul>
-                <br>
-            {% endif %}
-        {% endfor %}
-        </div>
-        {% endif %}
-        {% endif %}
-
         {% if runs_no_002 %}
         {% if "TSO500" in runs_no_002|map(attribute="assay_type") %}
         <div style="padding-top: 20px;">
@@ -569,12 +551,13 @@
         {% if closed_ticket_typos %}
         {% if "TSO500" in closed_ticket_typos|map(attribute="assay_type") %}
         <div style="padding-top: 20px; padding-bottom: 20px;">
-        <h5>Mismatches between 002 project name and Jira ticket (closed tickets)</h5>
+        <h5>Mismatches between run folder name and Jira ticket (closed tickets)</h5>
         {% for item in closed_ticket_typos %}
             {% if item.assay_type == "TSO500" %}
                 <b>Jira ticket name:</b> {{ item.jira_ticket_name }}
                 <br>
-                <b>002 project name:</b> {{ item.project_name_002 }}
+                <b>Run folder name:</b> {{ item.run_name }}
+                <br>
                 <br>
             {% endif %}
         {% endfor %}
@@ -585,12 +568,13 @@
         {% if open_ticket_typos %}
         {% if "TSO500" in open_ticket_typos|map(attribute="assay_type") %}
         <div style="padding-top: 20px; padding-bottom: 20px;">
-            <h5>Mismatches between 002 project name and Jira ticket (open tickets)</h5>
+            <h5>Mismatches between run folder name and Jira ticket (open tickets)</h5>
             {% for item in open_ticket_typos %}
             {% if item.assay_type == "TSO500" %}
                 <b>Jira ticket name:</b> {{ item.jira_ticket_name }}
                 <br>
-                <b>002 project name:</b> {{ item.project_name_002 }}
+                <b>Run folder name:</b> {{ item.run_name }}
+                <br>
                 <br>
             {% endif %}
             {% endfor %}
@@ -615,6 +599,28 @@
         {% endif %}
         {% endfor %}
         {% endfor %}
+        {% endif %}
+
+        {% if cancelled_runs %}
+        {% if "TSO500" in cancelled_runs|map(attribute="assay_type") %}
+        <div style="padding-top: 30px; padding-bottom: 30px;">
+            <h5>Runs that were not completed:</h5>
+        {% for run in cancelled_runs %}
+            {% if run.assay_type == 'TSO500' %}
+                <p><b>{{ run.run_name }}</b></p>
+                <ul>
+                    <li>
+                        Date Jira ticket created: {{ run.date_jira_ticket_created }}
+                    </li>
+                    <li>
+                        Reason run not released: {{ run.reason_not_released }}
+                    </li>
+                </ul>
+                <br>
+            {% endif %}
+        {% endfor %}
+        </div>
+        {% endif %}
         {% endif %}
 
         <div style="padding-top: 30px; padding-bottom: 20px;">
@@ -707,28 +713,6 @@
         {% endif %}
         {% endif %}
 
-        {% if cancelled_runs %}
-        {% if "TWE" in cancelled_runs|map(attribute="assay_type") %}
-        <div style="padding-top: 30px; padding-bottom: 30px;">
-            <h5>Runs that were not completed:</h5>
-        {% for run in cancelled_runs %}
-            {% if run.assay_type == 'TWE' %}
-                <p><b>{{ run.run_name }}</b></p>
-                <ul>
-                    <li>
-                        Date Jira ticket created: {{ run.date_jira_ticket_created }}
-                    </li>
-                    <li>
-                        Reason run not released: {{ run.reason_not_released }}
-                    </li>
-                </ul>
-                <br>
-            {% endif %}
-        {% endfor %}
-        </div>
-        {% endif %}
-        {% endif %}
-
         {% if runs_no_002 %}
         {% if "TWE" in runs_no_002|map(attribute="assay_type") %}
         <div style="padding-top: 20px;">
@@ -757,12 +741,13 @@
         {% if closed_ticket_typos %}
         {% if "TWE" in closed_ticket_typos|map(attribute="assay_type") %}
         <div style="padding-top: 20px; padding-bottom: 20px;">
-        <h5>Mismatches between 002 project name and Jira ticket (closed tickets)</h5>
+        <h5>Mismatches between run folder name and Jira ticket (closed tickets)</h5>
         {% for item in closed_ticket_typos %}
             {% if item.assay_type == "TWE" %}
                 <b>Jira ticket name:</b> {{ item.jira_ticket_name }}
                 <br>
-                <b>002 project name:</b> {{ item.project_name_002 }}
+                <b>Run folder name:</b> {{ item.run_name }}
+                <br>
                 <br>
             {% endif %}
         {% endfor %}
@@ -773,12 +758,13 @@
         {% if open_ticket_typos %}
         {% if "TWE" in open_ticket_typos|map(attribute="assay_type") %}
         <div style="padding-top: 20px; padding-bottom: 20px;">
-            <h5>Mismatches between 002 project name and Jira ticket (open tickets)</h5>
+            <h5>Mismatches between run folder name and Jira ticket (open tickets)</h5>
             {% for item in open_ticket_typos %}
             {% if item.assay_type == "TWE" %}
                 <b>Jira ticket name:</b> {{ item.jira_ticket_name }}
                 <br>
-                <b>002 project name:</b> {{ item.project_name_002 }}
+                <b>Run folder name:</b> {{ item.run_name }}
+                <br>
                 <br>
             {% endif %}
             {% endfor %}
@@ -803,6 +789,28 @@
         {% endif %}
         {% endfor %}
         {% endfor %}
+        {% endif %}
+
+        {% if cancelled_runs %}
+        {% if "TWE" in cancelled_runs|map(attribute="assay_type") %}
+        <div style="padding-top: 30px; padding-bottom: 30px;">
+            <h5>Runs that were not completed:</h5>
+        {% for run in cancelled_runs %}
+            {% if run.assay_type == 'TWE' %}
+                <p><b>{{ run.run_name }}</b></p>
+                <ul>
+                    <li>
+                        Date Jira ticket created: {{ run.date_jira_ticket_created }}
+                    </li>
+                    <li>
+                        Reason run not released: {{ run.reason_not_released }}
+                    </li>
+                </ul>
+                <br>
+            {% endif %}
+        {% endfor %}
+        </div>
+        {% endif %}
         {% endif %}
 
         <div style="padding-top: 30px; padding-bottom: 20px;">
@@ -854,7 +862,7 @@
                 {% endif %}
 
                 {% if runs_to_review_5.no_002_found %}
-                    <p><b>No 002 job was found:</b></p> 
+                    <p><b>No 002 job was found:</b></p>
                     <ul>
                         {% for entry in runs_to_review_5.no_002_found  %}
                             <li>{{ entry }}</li>
@@ -895,28 +903,6 @@
         {% endif %}
         {% endif %}
 
-        {% if cancelled_runs %}
-        {% if "SNP" in cancelled_runs|map(attribute="assay_type") %}
-        <div style="padding-top: 30px; padding-bottom: 30px;">
-            <h5>Runs that were not completed:</h5>
-        {% for run in cancelled_runs %}
-            {% if run.assay_type == 'SNP' %}
-                <p><b>{{ run.run_name }}</b></p>
-                <ul>
-                    <li>
-                        Date Jira ticket created: {{ run.date_jira_ticket_created }}
-                    </li>
-                    <li>
-                        Reason run not released: {{ run.reason_not_released }}
-                    </li>
-                </ul>
-                <br>
-            {% endif %}
-        {% endfor %}
-        </div>
-        {% endif %}
-        {% endif %}
-
         {% if runs_no_002 %}
         {% if "SNP" in runs_no_002|map(attribute="assay_type") %}
         <div style="padding-top: 20px;">
@@ -945,12 +931,13 @@
         {% if closed_ticket_typos %}
         {% if "SNP" in closed_ticket_typos|map(attribute="assay_type") %}
         <div style="padding-top: 20px; padding-bottom: 20px;">
-        <h5>Mismatches between 002 project name and Jira ticket (closed tickets)</h5>
+        <h5>Mismatches between run folder name and Jira ticket (closed tickets)</h5>
         {% for item in closed_ticket_typos %}
             {% if item.assay_type == "SNP" %}
                 <b>Jira ticket name:</b> {{ item.jira_ticket_name }}
                 <br>
-                <b>002 project name:</b> {{ item.project_name_002 }}
+                <b>Run folder name:</b> {{ item.run_name }}
+                <br>
                 <br>
             {% endif %}
         {% endfor %}
@@ -961,12 +948,13 @@
         {% if open_ticket_typos %}
         {% if "SNP" in open_ticket_typos|map(attribute="assay_type") %}
         <div style="padding-top: 20px; padding-bottom: 20px;">
-            <h5>Mismatches between 002 project name and Jira ticket (open tickets)</h5>
+            <h5>Mismatches between run folder name and Jira ticket (open tickets)</h5>
             {% for item in open_ticket_typos %}
             {% if item.assay_type == "SNP" %}
                 <b>Jira ticket name:</b> {{ item.jira_ticket_name }}
                 <br>
-                <b>002 project name:</b> {{ item.project_name_002 }}
+                <b>Run folder name:</b> {{ item.run_name }}
+                <br>
                 <br>
             {% endif %}
             {% endfor %}
@@ -992,7 +980,29 @@
         {% endfor %}
         {% endfor %}
         {% endif %}
-    
+
+        {% if cancelled_runs %}
+        {% if "SNP" in cancelled_runs|map(attribute="assay_type") %}
+        <div style="padding-top: 30px; padding-bottom: 30px;">
+            <h5>Runs that were not completed:</h5>
+        {% for run in cancelled_runs %}
+            {% if run.assay_type == 'SNP' %}
+                <p><b>{{ run.run_name }}</b></p>
+                <ul>
+                    <li>
+                        Date Jira ticket created: {{ run.date_jira_ticket_created }}
+                    </li>
+                    <li>
+                        Reason run not released: {{ run.reason_not_released }}
+                    </li>
+                </ul>
+                <br>
+            {% endif %}
+        {% endfor %}
+        </div>
+        {% endif %}
+        {% endif %}
+
     </div>
 
     <script>

--- a/TAT_audit/tests/test_TAT_queries.py
+++ b/TAT_audit/tests/test_TAT_queries.py
@@ -42,78 +42,78 @@ class TestGetDistance():
 
 
 class TestCreateRunDictAddAssay():
-        CEN_response = [
-            {
+    CEN_response = [
+        {
+            'id': 'project-GG4K2Q848FV2JpX3J4x7yGkx',
+            'level': 'CONTRIBUTE',
+            'permissionSources': ['XXX'],
+            'public': False,
+            'describe': {
                 'id': 'project-GG4K2Q848FV2JpX3J4x7yGkx',
-                'level': 'CONTRIBUTE',
-                'permissionSources': ['XXX'],
-                'public': False,
-                'describe': {
-                    'id': 'project-GG4K2Q848FV2JpX3J4x7yGkx',
-                    'name': '002_220825_A01295_0122_BH7WG5DRX2_CEN',
-                    'created': 1661526337000
-                }
-            },
-            {
-                'id': 'project-GFzp36j4b2B200PVBbXv4792',
-                'level': 'CONTRIBUTE',
-                'permissionSources': ['XXX'],
-                'public': False,
-                'describe': {
-                    'id': 'project-GFzp36j4b2B200PVBbXv4792',
-                    'name': '002_220817_A01295_0120_BH7MWYDRX2_CEN',
-                    'created': 1660920219000
-                }
-            },
-            {
-                'id': 'project-GF62QG045V8k6qX5F5gXXJV7',
-                'level': 'CONTRIBUTE',
-                'permissionSources': ['XXX'],
-                'public': False,
-                'describe': {
-                    'id': 'project-GF62QG045V8k6qX5F5gXXJV7',
-                    'name': '002_220706_A01303_0080_BH53VCDRX2_CEN',
-                    'created': 1657546800000
-                }
-            },
-            {
-                'id': 'project-G9B06xQ4543zy86jFVPGBq30',
-                'level': 'CONTRIBUTE',
-                'permissionSources': ['XXX'],
-                'public': False,
-                'describe': {
-                    'id': 'project-G9B06xQ4543zy86jFVPGBq30',
-                    'name': '002_220407_A01295_0080_AH333YDRX2_CEN',
-                    'created': 1649673078000
-                }
+                'name': '002_220825_A01295_0122_BH7WG5DRX2_CEN',
+                'created': 1661526337000
             }
-        ]
+        },
+        {
+            'id': 'project-GFzp36j4b2B200PVBbXv4792',
+            'level': 'CONTRIBUTE',
+            'permissionSources': ['XXX'],
+            'public': False,
+            'describe': {
+                'id': 'project-GFzp36j4b2B200PVBbXv4792',
+                'name': '002_220817_A01295_0120_BH7MWYDRX2_CEN',
+                'created': 1660920219000
+            }
+        },
+        {
+            'id': 'project-GF62QG045V8k6qX5F5gXXJV7',
+            'level': 'CONTRIBUTE',
+            'permissionSources': ['XXX'],
+            'public': False,
+            'describe': {
+                'id': 'project-GF62QG045V8k6qX5F5gXXJV7',
+                'name': '002_220706_A01303_0080_BH53VCDRX2_CEN',
+                'created': 1657546800000
+            }
+        },
+        {
+            'id': 'project-G9B06xQ4543zy86jFVPGBq30',
+            'level': 'CONTRIBUTE',
+            'permissionSources': ['XXX'],
+            'public': False,
+            'describe': {
+                'id': 'project-G9B06xQ4543zy86jFVPGBq30',
+                'name': '002_220407_A01295_0080_AH333YDRX2_CEN',
+                'created': 1649673078000
+            }
+        }
+    ]
 
-        TSO500_response = []
+    TSO500_response = []
 
-        def test_create_run_dict_add_assay(self):
-            tatq.audit_start_obj = dt.datetime(2022, 4, 1)
-            tatq.audit_end_obj = dt.datetime(2022, 9, 1)
-            CEN_dict = tatq.create_run_dict_add_assay(
-                'CEN', self.CEN_response
-            )
-            assert CEN_dict == {
-                '220825_A01295_0122_BH7WG5DRX2': {
-                    'project_id': 'project-GG4K2Q848FV2JpX3J4x7yGkx',
-                    'assay_type': 'CEN'
-                },
-                '220817_A01295_0120_BH7MWYDRX2': {
-                    'project_id': 'project-GFzp36j4b2B200PVBbXv4792',
-                    'assay_type': 'CEN'
-                },
-                '220706_A01303_0080_BH53VCDRX2': {
-                    'project_id': 'project-GF62QG045V8k6qX5F5gXXJV7',
-                    'assay_type': 'CEN'
-                },
-                '220407_A01295_0080_AH333YDRX2': {
-                    'project_id': 'project-G9B06xQ4543zy86jFVPGBq30',
-                    'assay_type': 'CEN'
-                }
+    def test_create_run_dict_add_assay(self):
+        tatq.audit_start_obj = dt.datetime(2022, 4, 1)
+        tatq.audit_end_obj = dt.datetime(2022, 9, 1)
+        CEN_dict = tatq.create_run_dict_add_assay(
+            'CEN', self.CEN_response
+        )
+        assert CEN_dict == {
+            '220825_A01295_0122_BH7WG5DRX2': {
+                'project_id': 'project-GG4K2Q848FV2JpX3J4x7yGkx',
+                'assay_type': 'CEN'
+            },
+            '220817_A01295_0120_BH7MWYDRX2': {
+                'project_id': 'project-GFzp36j4b2B200PVBbXv4792',
+                'assay_type': 'CEN'
+            },
+            '220706_A01303_0080_BH53VCDRX2': {
+                'project_id': 'project-GF62QG045V8k6qX5F5gXXJV7',
+                'assay_type': 'CEN'
+            },
+            '220407_A01295_0080_AH333YDRX2': {
+                'project_id': 'project-G9B06xQ4543zy86jFVPGBq30',
+                'assay_type': 'CEN'
+            }
         }, "Dictionary created incorrectly"
 
 
@@ -563,7 +563,7 @@ class TestGetClosestMatchInDict():
         )
         assert typo_ticket_info == {
             'jira_ticket_name': '220825_A01295_0122_BH7WG5DR',
-            'project_name_002': '220825_A01295_0122_BH7WG5DRX2',
+            'run_name': '220825_A01295_0122_BH7WG5DRX2',
             'assay_type': 'CEN'
         }, "Typo ticket added to dictionary incorrectly"
 
@@ -597,6 +597,7 @@ class TestGetClosestMatchInDict():
 
 
 class TestAddCalculationColumns():
+    tatq.pd_current_time = pd.Timestamp('2022-10-01 12:01:59')
     # Read in and set up column conversion
     test_csv = os.path.join(TEST_DATA_DIR, "all_assays_df_for_testing.csv")
     test_df = pd.read_csv(test_csv, sep=',')
@@ -612,7 +613,7 @@ class TestAddCalculationColumns():
 
     def test_add_calculation_columns(self):
         test_csv_cal = tatq.add_calculation_columns(
-            self.test_df, pd.Timestamp('2022-10-01 12:01:59')
+            self.test_df
         )
 
         assert pd.isnull(test_csv_cal.at[0, 'last_processing_step'])


### PR DESCRIPTION
- Updated so the starting point for checking for typos is the run name extracted from the Staging_Area52 run folder name rather than the run name as extracted from the 002 project name. This makes it easier to see where scientists vs us made errors.
- Instead of typos being bullet pointed within each assay with closed and open Jira ticket typos separated, ticket typos are all merged and presented as a table at the end of the report along with a table for 002 project name typos for less ugly jinja2 looping.
- Updated text in Jinja2 template so it's clearer why a Jira ticket may be flagged as created between the audit period for a released run that do not match a 002 project.
- Moved cancelled runs to end of the flags per assay.
- Changed TAT in days above bars to round to 1dp.
![image](https://user-images.githubusercontent.com/67269227/200623913-63514d73-eadf-4ce9-b043-4961208acb43.png)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/eastgenomics/themis/5)
<!-- Reviewable:end -->
