### PR TITLE
Upload day of week vs TAT plots

### DIFF
--- a/TAT_audit/templates/audit_template.html
+++ b/TAT_audit/templates/audit_template.html
@@ -72,6 +72,9 @@
         <div style="width: 600px; margin-left: 150px; padding-bottom: 20px;">
             {{ averages_1 }}
         </div>
+        <div style="padding-top: 30px; padding-bottom: 20px;">
+            {{ CEN_upload }}
+        </div>
             {% if runs_to_review_1 %}
                 <div style="padding-top: 30px; padding-bottom: 20px;">
                     <h5>Runs to review manually:</h5>
@@ -191,7 +194,7 @@
                         Date Jira ticket created: {{ run.date_jira_ticket_created }}
                     </li>
                     <li>
-                        Reason run not released: {{ run.reason_not_released }}
+                        Reason run not released: {{ run.jira_status }}
                     </li>
                 </ul>
                 <br>
@@ -208,6 +211,9 @@
         </div>
         <div style="width: 600px; margin-left: 150px; padding-bottom: 20px;">
             {{ averages_2 }}
+        </div>
+        <div style="padding-top: 30px; padding-bottom: 20px;">
+            {{ MYE_upload }}
         </div>
         {% if runs_to_review_2 %}
             <div style="padding-top: 30px; padding-bottom: 20px;">
@@ -328,7 +334,7 @@
                         Date Jira ticket created: {{ run.date_jira_ticket_created }}
                     </li>
                     <li>
-                        Reason run not released: {{ run.reason_not_released }}
+                        Reason run not released: {{ run.jira_status }}
                     </li>
                 </ul>
                 <br>
@@ -345,7 +351,9 @@
         <div style="width: 600px; margin-left: 150px; padding-bottom: 20px;">
             {{ averages_3 }}
         </div>
-
+        <div style="padding-top: 30px; padding-bottom: 20px;">
+            {{ TSO500_upload }}
+        </div>
         {% if runs_to_review_3 %}
             <div style="padding-top: 30px; padding-bottom: 20px;">
                 <h5>Runs to review manually:</h5>
@@ -465,7 +473,7 @@
                         Date Jira ticket created: {{ run.date_jira_ticket_created }}
                     </li>
                     <li>
-                        Reason run not released: {{ run.reason_not_released }}
+                        Reason run not released: {{ run.jira_status }}
                     </li>
                 </ul>
                 <br>
@@ -482,7 +490,9 @@
         <div style="width: 600px; margin-left: 150px; padding-bottom: 20px;">
             {{ averages_4 }}
         </div>
-
+        <div style="padding-top: 30px; padding-bottom: 20px;">
+            {{ TWE_upload }}
+        </div>
         {% if runs_to_review_4 %}
             <div style="padding-top: 30px; padding-bottom: 20px;">
                 <h5>Runs to review manually:</h5>
@@ -602,7 +612,7 @@
                         Date Jira ticket created: {{ run.date_jira_ticket_created }}
                     </li>
                     <li>
-                        Reason run not released: {{ run.reason_not_released }}
+                        Reason run not released: {{ run.jira_status }}
                     </li>
                 </ul>
                 <br>
@@ -619,7 +629,9 @@
         <div style="width: 600px; margin-left: 150px; padding-bottom: 20px;">
             {{ averages_5 }}
         </div>
-
+        <div style="padding-top: 30px; padding-bottom: 20px;">
+            {{ SNP_upload }}
+        </div>
         {% if runs_to_review_5 %}
             <div style="padding-top: 30px; padding-bottom: 20px;">
                 <h5>Runs to review manually:</h5>
@@ -739,7 +751,7 @@
                         Date Jira ticket created: {{ run.date_jira_ticket_created }}
                     </li>
                     <li>
-                        Reason run not released: {{ run.reason_not_released }}
+                        Reason run not released: {{ run.jira_status }}
                     </li>
                 </ul>
                 <br>


### PR DESCRIPTION
- Added plots into the audit report to show upload day of the week vs overall TAT for each assay
- Added cancelled runs into the outputted csv showing the details for all runs
- Changed 002 project searching to 5 days either side (as when auditing a period with the end date in the past, the 002 project may have been made >1 day after the run's actual date)
![image](https://user-images.githubusercontent.com/67269227/204864943-4676f083-ab13-4dbe-99fd-4321b63d96c4.png)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/eastgenomics/themis/8)
<!-- Reviewable:end -->
