### PR TITLE
Changed end of processing metric for CEN and TWE runs

### DIFF
--- a/TAT_audit/templates/audit_template.html
+++ b/TAT_audit/templates/audit_template.html
@@ -124,10 +124,10 @@
                     </ul>
                 {% endif %}
 
-                {% if runs_to_review_1.no_multiqc_found %}
-                    <p><b>No successful MultiQC job found:</b></p>
+                {% if runs_to_review_1.no_multiqc_or_excel_found %}
+                    <p><b>No successful Excel workbook job found:</b></p>
                     <ul>
-                        {% for entry in runs_to_review_1.no_multiqc_found  %}
+                        {% for entry in runs_to_review_1.no_multiqc_or_excel_found  %}
                             <li>{{ entry }}</li>
                         {% endfor %}
                     </ul>
@@ -264,10 +264,10 @@
                     </ul>
                 {% endif %}
 
-                {% if runs_to_review_2.no_multiqc_found %}
+                {% if runs_to_review_2.no_multiqc_or_excel_found %}
                     <p><b>No successful MultiQC job found:</b></p>
                     <ul>
-                        {% for entry in runs_to_review_2.no_multiqc_found  %}
+                        {% for entry in runs_to_review_2.no_multiqc_or_excel_found  %}
                             <li>{{ entry }}</li>
                         {% endfor %}
                     </ul>
@@ -403,10 +403,10 @@
                     </ul>
                 {% endif %}
 
-                {% if runs_to_review_3.no_multiqc_found %}
+                {% if runs_to_review_3.no_multiqc_or_excel_found %}
                     <p><b>No successful MultiQC job found:</b></p>
                     <ul>
-                        {% for entry in runs_to_review_3.no_multiqc_found  %}
+                        {% for entry in runs_to_review_3.no_multiqc_or_excel_found  %}
                             <li>{{ entry }}</li>
                         {% endfor %}
                     </ul>
@@ -542,10 +542,10 @@
                     </ul>
                 {% endif %}
 
-                {% if runs_to_review_4.no_multiqc_found %}
-                    <p><b>No successful MultiQC job found:</b></p>
+                {% if runs_to_review_4.no_multiqc_or_excel_found %}
+                    <p><b>No successful Excel workbooks job found:</b></p>
                     <ul>
-                        {% for entry in runs_to_review_4.no_multiqc_found  %}
+                        {% for entry in runs_to_review_4.no_multiqc_or_excel_found  %}
                             <li>{{ entry }}</li>
                         {% endfor %}
                     </ul>
@@ -681,10 +681,10 @@
                     </ul>
                 {% endif %}
 
-                {% if runs_to_review_5.no_multiqc_found %}
+                {% if runs_to_review_5.no_multiqc_or_excel_found %}
                     <p><b>No successful MultiQC job found:</b></p>
                     <ul>
-                        {% for entry in runs_to_review_5.no_multiqc_found  %}
+                        {% for entry in runs_to_review_5.no_multiqc_or_excel_found  %}
                             <li>{{ entry }}</li>
                         {% endfor %}
                     </ul>


### PR DESCRIPTION
- For Dias (CEN and TWE) runs, the last job is not a MultiQC job but generating the variant workbook. For these runs, if the run is released ('All samples released'), it now takes the final job which creates the Excel before the ticket was resolved (so reanalysis jobs aren't included). If the run isn't released it just takes the time the last job finished to create the Excel.
- Updated HTML wording.
- Updated upload day vs TAT figs so all days of the week are shown even if there is no data so easier to compare.
![image](https://user-images.githubusercontent.com/67269227/205281511-4b4d50b1-6a87-4fbf-83bd-d67a00830afa.png)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/eastgenomics/themis/9)
<!-- Reviewable:end -->
